### PR TITLE
Wrong force pack content names+ fix for Unit Search Rules

### DIFF
--- a/src/data/force-packs-mechs.ts
+++ b/src/data/force-packs-mechs.ts
@@ -106,11 +106,11 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         groupLabel: "Star",
         tech: "clan",
         members: [
-            "Elemental Battle Armor [Laser]",
-            "Elemental Battle Armor [Laser]",
-            "Elemental Battle Armor [Laser]",
-            "Elemental Battle Armor [Laser]",
-            "Elemental Battle Armor [Laser]",
+            "Elemental Battle Armor [Laser] (sqd5)",
+            "Elemental Battle Armor [Laser] (sqd5)",
+            "Elemental Battle Armor [Laser] (sqd5)",
+            "Elemental Battle Armor [Laser] (sqd5)",
+            "Elemental Battle Armor [Laser] (sqd5)",
         ],
     },
     {

--- a/src/data/force-packs-mechs.ts
+++ b/src/data/force-packs-mechs.ts
@@ -46,11 +46,11 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         groupLabel: "Star",
         tech: "clan",
         members: [
-            "Behemoth (Stone Rhino) (Standard)",
-            "Supernova (Standard)",
-            "Marauder IIC (Standard)",
-            "Warhammer IIC (Standard)",
-            "Hunchback IIC (Standard)",
+            "Behemoth (Stone Rhino)",
+            "Supernova",
+            "Marauder IIC",
+            "Warhammer IIC",
+            "Hunchback IIC",
         ],
     },
     {
@@ -82,11 +82,11 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         groupLabel: "Star",
         tech: "clan",
         members: [
-            "Goshawk (Vapor Eagle) (Standard)",
-            "Hellhound (Conjurer) (Standard)",
-            "Peregrine (Horned Owl) (Standard)",
-            "Vixen (Incubus) (Standard)",
-            "Piranha (Standard)",
+            "Goshawk (Vapor Eagle)",
+            "Hellhound (Conjurer)",
+            "Peregrine (Horned Owl)",
+            "Vixen (Incubus)",
+            "Piranha",
         ],
     },
     {
@@ -94,11 +94,11 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         groupLabel: "Star",
         tech: "clan",
         members: [
-            "Kodiak (Standard)",
-            "Pack Hunter (Standard)",
+            "Kodiak",
+            "Pack Hunter",
             "Hellion Prime",
             "Fire Falcon Prime",
-            "Baboon (Howler) (Standard)",
+            "Baboon (Howler)",
          ],
     },
     {
@@ -121,7 +121,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
             "Marauder MAD-3R",
             "Archer ARC-2R",
             "Valkyrie VLK-QA",
-            "Stinger STG-3Rer",
+            "Stinger STG-3R",
         ],
     },{
         name: "Inner Sphere Battle Lance",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,7 +44,7 @@ export async function getMULASSearchResults(
     if( mechRules.toLowerCase() === "introductory" ) {
         rulesNumbersURI.push( "&Rules=55" );
     }
-    if( mechRules.toLowerCase().indexOf("standard") > -1 ) {
+    if( mechRules.toLowerCase() === "standard" ) {
         rulesNumbersURI.push( "&Rules=4" );
     }
     if( mechRules.toLowerCase() === "advanced" ) {
@@ -60,7 +60,7 @@ export async function getMULASSearchResults(
     if( mechRules.toLowerCase() === "era specific" ) {
         rulesNumbersURI.push( "&Rules=56" );
     }
-    if( mechRules.toLowerCase() === "experimental" ) {
+    if( mechRules.toLowerCase() === "unknown" ) {//unknown
         rulesNumbersURI.push( "&Rules=78" );
     }
 
@@ -104,7 +104,7 @@ export async function getMULASSearchResults(
         }
 
 
-        url += rulesNumbersURI.join();
+        url += rulesNumbersURI.join("");
         url += typesFilterURI.join();
         url += techFilterURI.join();
         url += roleFilterURI.join();


### PR DESCRIPTION
Solves #42 

MUL has changed naming standards and removed "(standard)", and Added squad size to Elementals.  See Sept 11, 2002, and June 6, 2022 entries at http://masterunitlist.info/Blog/Index .

Also to fix the rifleman search, had to change Rules Search.  ',' appended by default into Rules field Value causes search to skip rules section.  Changed string match to follow pattern, and fixed extra , in query string.
